### PR TITLE
Add dancefloor component: loads poseNet, captures pose from webcam

### DIFF
--- a/dark-matter-disco/package.json
+++ b/dark-matter-disco/package.json
@@ -20,9 +20,11 @@
     "@angular/platform-browser": "~8.0.1",
     "@angular/platform-browser-dynamic": "~8.0.1",
     "@angular/router": "~8.0.1",
+    "@tensorflow-models/posenet": "^2.0.0",
+    "@tensorflow/tfjs": "^1.2.1",
     "express": "^4.17.1",
     "path": "^0.12.7",
-    "rxjs": "~6.4.0",
+    "rxjs": "^6.4.0",
     "tslib": "^1.9.0",
     "zone.js": "~0.9.1"
   },

--- a/dark-matter-disco/src/app/app.component.html
+++ b/dark-matter-disco/src/app/app.component.html
@@ -4,6 +4,7 @@
     {{ title }}!
   </h1>
   <app-audio></app-audio>
+  <app-dance-floor></app-dance-floor>
 </div>
 
 

--- a/dark-matter-disco/src/app/app.module.ts
+++ b/dark-matter-disco/src/app/app.module.ts
@@ -3,13 +3,15 @@ import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
 import { AudioComponent } from './audio/audio.component';
+import { DanceFloorComponent } from './dance-floor/dance-floor.component';
 
 
 
 @NgModule({
   declarations: [
     AppComponent,
-    AudioComponent
+    AudioComponent,
+    DanceFloorComponent
   ],
   imports: [
     BrowserModule,

--- a/dark-matter-disco/src/app/dance-floor/dance-floor.component.css
+++ b/dark-matter-disco/src/app/dance-floor/dance-floor.component.css
@@ -1,0 +1,3 @@
+#webcam {
+  opacity: 0.4;
+}

--- a/dark-matter-disco/src/app/dance-floor/dance-floor.component.html
+++ b/dark-matter-disco/src/app/dance-floor/dance-floor.component.html
@@ -1,0 +1,8 @@
+<!-- This is the video player attached to the webcam that PoseNet uses -->
+{{userPose ? 'pose found!' : 'loading pose...'}}
+<div id="video-container">
+  <video autoplay="true" id="webcam" #webcamVideo width="500" height="500">
+  
+  </video>
+</div>
+

--- a/dark-matter-disco/src/app/dance-floor/dance-floor.component.spec.ts
+++ b/dark-matter-disco/src/app/dance-floor/dance-floor.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DanceFloorComponent } from './dance-floor.component';
+
+describe('DanceFloorComponent', () => {
+  let component: DanceFloorComponent;
+  let fixture: ComponentFixture<DanceFloorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DanceFloorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DanceFloorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/dark-matter-disco/src/app/dance-floor/dance-floor.component.ts
+++ b/dark-matter-disco/src/app/dance-floor/dance-floor.component.ts
@@ -1,0 +1,71 @@
+import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import { load } from '@tensorflow-models/posenet';
+import { from, Observable } from 'rxjs';
+/**
+ * This component is responsible for managing dancer states (i.e pose data)
+ * coming either directly from PoseNet data or for other user via web sockets
+ */
+
+
+@Component({
+  selector: 'app-dance-floor',
+  templateUrl: './dance-floor.component.html',
+  styleUrls: ['./dance-floor.component.css']
+})
+export class DanceFloorComponent implements AfterViewInit {
+
+  constructor() {}
+
+  userPose: any;
+  
+  @ViewChild('webcamVideo', {static: false}) webcamVideo: any;
+  
+  ngAfterViewInit() {
+    const webcamVideo = this.webcamVideo;
+
+   /** 
+    * Set up webcam stream and PoseNet
+    * */
+    const poseNetModel: any = {
+      architecture: 'MobileNetV1',
+      outputStride: 16,
+      inputResolution: 321,
+      multiplier: 0.75
+    };
+
+    const poseNetOptions: any = {
+      flipHorizontal: true,
+      decodingMethod: 'single-person',
+    };
+    
+    let poseStream: any;
+
+    if (navigator.mediaDevices.getUserMedia) {
+      const webcamStream = from(navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } }));
+      webcamStream.subscribe((stream) => { 
+          webcamVideo.nativeElement.srcObject = stream;
+          from(load(poseNetModel)).subscribe((net) => {
+              poseStream = Observable.create((observer) => {
+                // Yield a single value and complete
+                setInterval(() => {
+                  from(net.estimatePoses(webcamVideo.nativeElement, poseNetOptions))
+                  .subscribe((poses) => {
+                      observer.next(poses);
+                    });
+                }, 100);
+              });  
+
+              poseStream.subscribe((poses)=>{ 
+                this.userPose = poses[0];
+              })
+             
+          });
+      });  
+    }
+
+
+  
+  
+  }
+
+}


### PR DESCRIPTION
This is just the initial setup of a dance floor component which at this point pulls pose data from the webcam.  The idea is that it will also receive pose data from the web sockets

It can then render Dancer Components with pose data from either the user webcam or the friends pose data from the websocket.

